### PR TITLE
Fixed NullPointerException

### DIFF
--- a/src/main/java/za/ac/sun/cs/coastal/COASTAL.java
+++ b/src/main/java/za/ac/sun/cs/coastal/COASTAL.java
@@ -2021,8 +2021,8 @@ public class COASTAL {
 		ImmutableConfiguration config = ConfigHelper.loadConfiguration(log, args);
 		if (config != null) {
 			new COASTAL(log, config).start(false);
+			new Banner('~').println("COASTAL DONE (" + config.getString("run-name", "?") + ")").display(log);
 		}
-		new Banner('~').println("COASTAL DONE (" + config.getString("run-name", "?") + ")").display(log);
 		LogManager.shutdown(true);
 	}
 


### PR DESCRIPTION
Added null check as post-run banner generation will fail with a NullPointerException if the properties file path is missing or invalid.